### PR TITLE
Updated README to include benchmarking results

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,23 +6,23 @@ This library uses https://github.com/zac-williamson/noir-bignum as a dependency.
 
 ## Benchmarks
 
-We ran a benchmark to measure the number of gates of the circuit, the proving time and the verification time of the RSA verification. The benchmark includes two main scenarios: the signature verification of one signature and 10 different signatures. For both scenarios, we reported all the metrics mentioned above.
+The benchmarking source code and its details can be found in [this repository](https://github.com/hashcloak/noir_rsa_bench).
 
-On the one hand, the number of gates is measured using the `bb gates` command. On the other hand, the timing measures are taken using the `hyperfine` command line tool which takes the average of ten executions of the proving and verification commands. These averages are the ones reported in the results presented here.
+For the results, "UP" stands for UltraPlonk and "UH" stands for UltraHonk.
 
-The results for the verification of one signature are the following:
+The benchmark results for the verification of one signature are the following:
 
-| **Bit length** | **Circuit size** | **Avg. proving time (BB) [ms]** | **Avg. verification time (BB) [ms]** | **Avg. proving time (UH) [ms]** | **Avg. verification time (UH) [ms]** |
-|----------------|------------------|---------------------------------|--------------------------------------|---------------------------------|--------------------------------------|
-|           1024 |             2204 |                           234.8 |                                 33.2 |                             181 |                                 37.1 |
-|           2048 |             7131 |                           345.6 |                                 32.7 |                           261.9 |                                 36.4 |
+| **Bit length** | **Circuit size** | **Avg. proving time (UP) [ms]**  | **Avg. proving time (UH) [ms]** | 
+|----------------|------------------|---------------------------------|--------------------------------------|
+|           1024 |             2204 |                           234.8 |                             181 |
+|           2048 |             7131 |                           345.6 |                           261.9 |
 
-On the other hand, the results for the verification of 10 signatures are the following:
+Also, the results for the verification of 10 signatures are the following:
 
-| **Bit length** | **Circuit size** | **Avg. proving time (BB) [ms]** | **Avg. verification time (BB) [ms]** | **Avg. proving time (UH) [ms]** | **Avg. verification time (UH) [ms]** |
-|----------------|------------------|---------------------------------|--------------------------------------|---------------------------------|--------------------------------------|
-|           1024 |            21516 |                           970.9 |                                 32.3 |                           514.4 |                                 36.7 |
-|           2048 |            63821 |                          1801.7 |                                 32.3 |                           964.2 |                                   37 |
+| **Bit length** | **Circuit size** | **Avg. proving time (UP) [ms]** | **Avg. proving time (UH) [ms]** |
+|----------------|------------------|---------------------------------|--------------------------------------|
+|           1024 |            21516 |                           970.9 |                           514.4 |                                 36.7 |
+|           2048 |            63821 |                          1801.7 |                           964.2 |
 
 ### Costs
 

--- a/README.md
+++ b/README.md
@@ -21,17 +21,10 @@ Also, the results for the verification of 10 signatures are the following:
 
 | **Bit length** | **Circuit size** | **Avg. proving time (UP) [ms]** | **Avg. proving time (UH) [ms]** |
 |----------------|------------------|---------------------------------|--------------------------------------|
-|           1024 |            21516 |                           970.9 |                           514.4 |                                 36.7 |
+|           1024 |            21516 |                           970.9 |                           514.4 |   
 |           2048 |            63821 |                          1801.7 |                           964.2 |
 
-### Costs
-
-Rough cost:
-
-- 2,048 bit RSA: 26,888 gates per verification
-- 1,024 bit RSA: 11,983 gates per verification
-
-A circuit that verifies 1 signature (and does nothing else) will cost ~32k due to initialization costs of lookup tables
+The benchmarks were executed using a laptop with Intel(R) Core(TM) i7-13700H CPU and 32 GB of RAM.
 
 ## Dependencies
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Optimized Noir library that evaluates RSA signatures.
 
-This library uses https://github.com/zac-williamson/noir-bignum as a dependency.
+This library uses https://github.com/noir-lang/noir-bignum as a dependency.
 
 ## Benchmarks
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,23 @@ This library uses https://github.com/zac-williamson/noir-bignum as a dependency.
 
 ## Benchmarks
 
-TODO
+We ran a benchmark to measure the number of gates of the circuit, the proving time and the verification time of the RSA verification. The benchmark includes two main scenarios: the signature verification of one signature and 10 different signatures. For both scenarios, we reported all the metrics mentioned above.
+
+On the one hand, the number of gates is measured using the `bb gates` command. On the other hand, the timing measures are taken using the `hyperfine` command line tool which takes the average of ten executions of the proving and verification commands. These averages are the ones reported in the results presented here.
+
+The results for the verification of one signature are the following:
+
+| **Bit length** | **Circuit size** | **Avg. proving time (BB) [ms]** | **Avg. verification time (BB) [ms]** | **Avg. proving time (UH) [ms]** | **Avg. verification time (UH) [ms]** |
+|----------------|------------------|---------------------------------|--------------------------------------|---------------------------------|--------------------------------------|
+|           1024 |             2204 |                           234.8 |                                 33.2 |                             181 |                                 37.1 |
+|           2048 |             7131 |                           345.6 |                                 32.7 |                           261.9 |                                 36.4 |
+
+On the other hand, the results for the verification of 10 signatures are the following:
+
+| **Bit length** | **Circuit size** | **Avg. proving time (BB) [ms]** | **Avg. verification time (BB) [ms]** | **Avg. proving time (UH) [ms]** | **Avg. verification time (UH) [ms]** |
+|----------------|------------------|---------------------------------|--------------------------------------|---------------------------------|--------------------------------------|
+|           1024 |            21516 |                           970.9 |                                 32.3 |                           514.4 |                                 36.7 |
+|           2048 |            63821 |                          1801.7 |                                 32.3 |                           964.2 |                                   37 |
 
 ### Costs
 

--- a/signature_gen/src/main.rs
+++ b/signature_gen/src/main.rs
@@ -3,12 +3,10 @@ use rsa::pkcs1v15::Signature;
 use rsa::pkcs1v15::VerifyingKey;
 use rsa::{RsaPrivateKey, RsaPublicKey};
 
+use rand;
+use rsa::signature::{SignatureEncoding, Signer, Verifier};
 use rsa::traits::PublicKeyParts;
 use sha2::Sha256;
-use rsa::signature::{
-    SignatureEncoding, Signer, Verifier,
-};
-use rand;
 
 use noir_bignum_paramgen::{bn_limbs, bn_runtime_instance};
 
@@ -27,20 +25,19 @@ fn generate_2048_bit_signature_parameters() {
 
     let sig_uint: BigUint = BigUint::from_bytes_be(sig_bytes);
 
-
     let sig_str = bn_limbs(sig_uint.clone(), 2048);
-    println!("let signature: BigNum<18, Params2048> = BigNum::from_array({});", sig_str.as_str());
+    println!(
+        "let signature: BigNum<18, Params2048> = BigNum::from_array({});",
+        sig_str.as_str()
+    );
 
     let r = bn_runtime_instance(pub_key.n().clone(), 2048, String::from("BNInstance"));
     println!("{}", r.as_str());
 }
 
-
 fn main() {
     generate_2048_bit_signature_parameters();
 }
-
-
 
 fn test_signature_generation_impl() {
     let mut rng = rand::thread_rng();
@@ -57,11 +54,9 @@ fn test_signature_generation_impl() {
         &Signature::try_from(sig.as_slice()).unwrap(),
     );
     result.expect("failed to verify");
-
 }
 
 #[test]
-fn test_signature_generation()
-{
+fn test_signature_generation() {
     test_signature_generation_impl();
 }


### PR DESCRIPTION
# Description

## Summary\*

This PR adds some benchmarking results to the RSA verification implementation.

## Additional Context

We have included the benchmarking results in the repository's README. The benchmark measures the number of gates and the proving time using UltraPlonk and UltraHonk.

We removed the old gate count because it was significantly inconsistent with our results. However, I would recommend double-checking both measures. For our case, we reported the gate count provided by the command `bb gates -b <target_path>`.

For a detailed description of the benchmarks, please refer to the [benchmarking repository](https://github.com/hashcloak/noir_rsa_bench)