### PR TITLE
chore: bump bignum dependency

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        toolchain: [nightly, 0.32.0]
+        toolchain: [nightly, 0.34.0]
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -39,7 +39,7 @@ jobs:
       - name: Install Nargo
         uses: noir-lang/noirup@v0.1.3
         with:
-          toolchain: 0.32.0
+          toolchain: 0.34.0
 
       - name: Run formatter
         working-directory: ./lib

--- a/lib/Nargo.toml
+++ b/lib/Nargo.toml
@@ -2,7 +2,7 @@
 name = "noir_rsa"
 type = "lib"
 authors = [""]
-compiler_version = ">=0.32.0"
+compiler_version = ">=0.34.0"
 
 [dependencies]
-bignum = {tag = "v0.3.2", git = "https://github.com/noir-lang/noir-bignum"}
+bignum = {tag = "v0.3.3", git = "https://github.com/noir-lang/noir-bignum"}


### PR DESCRIPTION
# Description

## Problem\*

Resolves #10

## Summary\*

Updates the bignum dependency to support new version of noir

## Additional Context



# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
